### PR TITLE
Prepare v2.0 cleanup connection breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ Os campos acima tem os seguintes efeitos:
 
 - **fixtures_namespace**: O namespace das fixtures, caso omitido o padrão é *Application\Fixture*.
 - **entities_namespace**: O namespace padrão das entidades, caso omitido o padrão é *Application\Entity*. É importante notar que é possível especificar um namespace para cada entidade dentro da opção *fixtures*.
-- **clean_connection**: Configuração obrigatória de conexão exclusiva para a limpeza do banco. Somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão.
+- **clean_connection**: Configuração obrigatória de conexão exclusiva para a limpeza do banco. Somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão. Defina essa chave no `config/autoload/*.php` do projeto consumidor.
 - **fixtures**
     - **Nome de uma entidade**:
         - **identifier**: Campo que identifica a entidade, caso omitido o padrão é *id*.
         - **entity_name**: Nome completo da entidade, caso omitido o padrão é o namespace definido em *entities_namespace* junto com o nome simples da entidade.
     - **base**: Lista que contém as entidades que serão carregadas sempre que rodar os testes.
 
-> **Breaking change (v2.0):** na versão `v2.0`, `pandora-testes.clean_connection` passa a ser obrigatória. A biblioteca falhará na criação do `FixtureBuilder` quando essa chave não estiver configurada, para evitar que a limpeza rode acidentalmente na conexão padrão do Doctrine.
+> **Breaking change (v2.0):** na versão `v2.0`, `pandora-testes.clean_connection` passa a ser obrigatória. A biblioteca falhará quando a limpeza do banco for acionada sem essa chave configurada, para evitar que a limpeza rode acidentalmente na conexão padrão do Doctrine.
 
 ### Doctrine Fixtures
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ Abaixo temos um exemplo de uma configuração mais completa:
     'fixtures_namespace' => 'Application\Fixture',
     'entities_namespace' => 'Application\Entity',
     'clean-after-suite' => false,
+    'clean_connection' => array(
+        'driver' => 'pdo_pgsql',
+        'host' => '127.0.0.1',
+        'port' => 5432,
+        'dbname' => 'app_test',
+        'user' => 'postgres',
+        'password' => 'secret',
+        'charset' => 'UTF8'
+    ),
     'fixtures' => array(
         'base' => array('usuarioWeb'),
         'Usuario' => array(
@@ -60,6 +69,7 @@ Os campos acima tem os seguintes efeitos:
 
 - **fixtures_namespace**: O namespace das fixtures, caso omitido o padrão é *Application\Fixture*.
 - **entities_namespace**: O namespace padrão das entidades, caso omitido o padrão é *Application\Entity*. É importante notar que é possível especificar um namespace para cada entidade dentro da opção *fixtures*.
+- **clean_connection**: Configuração opcional de conexão exclusiva para a limpeza do banco. Quando informada, somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão. Se omitida, a limpeza continua usando a conexão padrão do Doctrine.
 - **fixtures**
     - **Nome de uma entidade**:
         - **identifier**: Campo que identifica a entidade, caso omitido o padrão é *id*.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Caso os testes necessitem de Selenium2 rodando em background, o seguinte comando
 $ java -jar vendor/bin/selenium-server-standalone-2.53.0.jar
 ```
 
-### Configurações Opcionais
+### Configuração
 
 Abaixo temos um exemplo de uma configuração mais completa:
 
@@ -69,12 +69,14 @@ Os campos acima tem os seguintes efeitos:
 
 - **fixtures_namespace**: O namespace das fixtures, caso omitido o padrão é *Application\Fixture*.
 - **entities_namespace**: O namespace padrão das entidades, caso omitido o padrão é *Application\Entity*. É importante notar que é possível especificar um namespace para cada entidade dentro da opção *fixtures*.
-- **clean_connection**: Configuração opcional de conexão exclusiva para a limpeza do banco. Quando informada, somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão. Se omitida, a limpeza continua usando a conexão padrão do Doctrine.
+- **clean_connection**: Configuração obrigatória de conexão exclusiva para a limpeza do banco. Somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão.
 - **fixtures**
     - **Nome de uma entidade**:
         - **identifier**: Campo que identifica a entidade, caso omitido o padrão é *id*.
         - **entity_name**: Nome completo da entidade, caso omitido o padrão é o namespace definido em *entities_namespace* junto com o nome simples da entidade.
     - **base**: Lista que contém as entidades que serão carregadas sempre que rodar os testes.
+
+> **Breaking change (v2.0):** na versão `v2.0`, `pandora-testes.clean_connection` passa a ser obrigatória. A biblioteca falhará na criação do `FixtureBuilder` quando essa chave não estiver configurada, para evitar que a limpeza rode acidentalmente na conexão padrão do Doctrine.
 
 ### Doctrine Fixtures
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Os campos acima tem os seguintes efeitos:
 
 - **fixtures_namespace**: O namespace das fixtures, caso omitido o padrão é *Application\Fixture*.
 - **entities_namespace**: O namespace padrão das entidades, caso omitido o padrão é *Application\Entity*. É importante notar que é possível especificar um namespace para cada entidade dentro da opção *fixtures*.
-- **connection**: Configuração obrigatória de conexão usada pela biblioteca para limpar o banco, carregar fixtures, buscar associações e atualizar entidades criadas durante os testes. Os valores informados sobrescrevem os parâmetros da conexão padrão. Defina essa chave no `config/autoload/*.php` do projeto consumidor.
+- **connection**: Configuração obrigatória de conexão usada pela biblioteca para limpar o banco, carregar fixtures, buscar associações e atualizar entidades criadas durante os testes.
 - **fixtures**
     - **Nome de uma entidade**:
         - **identifier**: Campo que identifica a entidade, caso omitido o padrão é *id*.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Abaixo temos um exemplo de uma configuração mais completa:
     'fixtures_namespace' => 'Application\Fixture',
     'entities_namespace' => 'Application\Entity',
     'clean-after-suite' => false,
-    'clean_connection' => array(
+    'connection' => array(
         'driver' => 'pdo_pgsql',
         'host' => '127.0.0.1',
         'port' => 5432,
@@ -69,14 +69,14 @@ Os campos acima tem os seguintes efeitos:
 
 - **fixtures_namespace**: O namespace das fixtures, caso omitido o padrão é *Application\Fixture*.
 - **entities_namespace**: O namespace padrão das entidades, caso omitido o padrão é *Application\Entity*. É importante notar que é possível especificar um namespace para cada entidade dentro da opção *fixtures*.
-- **clean_connection**: Configuração obrigatória de conexão exclusiva para a limpeza do banco. Somente o `clean()` usará essa conexão; criação e atualização de fixtures continuam usando o `EntityManager` principal do Doctrine. Os valores informados sobrescrevem os parâmetros da conexão padrão. Defina essa chave no `config/autoload/*.php` do projeto consumidor.
+- **connection**: Configuração obrigatória de conexão usada pela biblioteca para limpar o banco, carregar fixtures, buscar associações e atualizar entidades criadas durante os testes. Os valores informados sobrescrevem os parâmetros da conexão padrão. Defina essa chave no `config/autoload/*.php` do projeto consumidor.
 - **fixtures**
     - **Nome de uma entidade**:
         - **identifier**: Campo que identifica a entidade, caso omitido o padrão é *id*.
         - **entity_name**: Nome completo da entidade, caso omitido o padrão é o namespace definido em *entities_namespace* junto com o nome simples da entidade.
     - **base**: Lista que contém as entidades que serão carregadas sempre que rodar os testes.
 
-> **Breaking change (v2.0):** na versão `v2.0`, `pandora-testes.clean_connection` passa a ser obrigatória. A biblioteca falhará quando a limpeza do banco for acionada sem essa chave configurada, para evitar que a limpeza rode acidentalmente na conexão padrão do Doctrine.
+> **Breaking change (v2.0):** na versão `v2.0`, `pandora-testes.connection` passa a ser obrigatória. A biblioteca deixa de usar o `EntityManager` padrão da aplicação para manipular fixtures e passa a usar apenas a conexão configurada nessa chave.
 
 ### Doctrine Fixtures
 

--- a/src/PandoraTestes/Context/PandoraContext.php
+++ b/src/PandoraTestes/Context/PandoraContext.php
@@ -38,7 +38,7 @@ abstract class PandoraContext implements Context, MinkAwareContext
      */
     public function givenExists($entity)
     {
-        $this->getFixtureBuilder()->load($entity, true, $this->_getEntityManager());
+        $this->getFixtureBuilder()->load($entity, true);
     }
 
     /**
@@ -48,17 +48,19 @@ abstract class PandoraContext implements Context, MinkAwareContext
      */
     public function theFieldOfFixtureIsValue($field, $fixture, $value)
     {
-        $entity = $this->getFixtureBuilder()->load($fixture, true, $this->_getEntityManager());
+        $fixtureBuilder = $this->getFixtureBuilder();
+        $entityManager = $fixtureBuilder->getEntityManager();
+        $entity = $fixtureBuilder->load($fixture, true);
         $method = 'set' . ucfirst($field);
         if (!method_exists($entity, $method)) {
             $class = get_class($entity);
             throw new \Exception("There is no method named $method in class $class", 1);
         }
-        $entity = $this->_getEntityManager()->merge($entity);
+        $entity = $entityManager->merge($entity);
         $value = $this->processValue($value);
         $entity->{$method}($value);
-        $this->_getEntityManager()->flush($entity);
-        $this->getFixtureBuilder()->update($fixture, $entity);
+        $entityManager->flush($entity);
+        $fixtureBuilder->update($fixture, $entity);
     }
 
     /**
@@ -148,14 +150,6 @@ abstract class PandoraContext implements Context, MinkAwareContext
     }
 
     /**
-     * @return Doctrine\ORM\EntityManager
-     */
-    protected function _getEntityManager()
-    {
-        return self::$zendApp->getServiceManager()->get('Doctrine\ORM\EntityManager');
-    }
-
-    /**
      * @return FixtureBuilder
      */
     protected function getFixtureBuilder()
@@ -172,12 +166,7 @@ abstract class PandoraContext implements Context, MinkAwareContext
      */
     protected static function getStaticFixtureBuilder()
     {
-        $fixtureBuilder = self::$zendApp->getServiceManager()->get('PandoraTestes\Fixture\FixtureBuilder');
-        $fixtureBuilder->setEntityManager(
-            self::$zendApp->getServiceManager()->get('Doctrine\ORM\EntityManager')
-        );
-
-        return $fixtureBuilder;
+        return self::$zendApp->getServiceManager()->get('PandoraTestes\Fixture\FixtureBuilder');
     }
 
     public function spin($text, $negative = false, $canFail = true, $wait = null)

--- a/src/PandoraTestes/Context/PandoraContext.php
+++ b/src/PandoraTestes/Context/PandoraContext.php
@@ -123,7 +123,7 @@ abstract class PandoraContext implements Context, MinkAwareContext
     public static function clean()
     {
         if (self::getCleanAfterSuite()) {
-            $this->getFixtureBuilder()->clean();
+            self::getStaticFixtureBuilder()->clean();
         }
     }
 
@@ -161,11 +161,23 @@ abstract class PandoraContext implements Context, MinkAwareContext
     protected function getFixtureBuilder()
     {
         if (!$this->_fixtureBuilder) {
-            $this->_fixtureBuilder = self::$zendApp->getServiceManager()->get('PandoraTestes\Fixture\FixtureBuilder');
-            $this->_fixtureBuilder->setEntityManager($this->_getEntityManager());
+            $this->_fixtureBuilder = self::getStaticFixtureBuilder();
         }
 
         return $this->_fixtureBuilder;
+    }
+
+    /**
+     * @return FixtureBuilder
+     */
+    protected static function getStaticFixtureBuilder()
+    {
+        $fixtureBuilder = self::$zendApp->getServiceManager()->get('PandoraTestes\Fixture\FixtureBuilder');
+        $fixtureBuilder->setEntityManager(
+            self::$zendApp->getServiceManager()->get('Doctrine\ORM\EntityManager')
+        );
+
+        return $fixtureBuilder;
     }
 
     public function spin($text, $negative = false, $canFail = true, $wait = null)

--- a/src/PandoraTestes/Context/PandoraContext.php
+++ b/src/PandoraTestes/Context/PandoraContext.php
@@ -49,7 +49,7 @@ abstract class PandoraContext implements Context, MinkAwareContext
     public function theFieldOfFixtureIsValue($field, $fixture, $value)
     {
         $fixtureBuilder = $this->getFixtureBuilder();
-        $entityManager = $fixtureBuilder->getEntityManager();
+        $entityManager = $this->_getEntityManager();
         $entity = $fixtureBuilder->load($fixture, true);
         $method = 'set' . ucfirst($field);
         if (!method_exists($entity, $method)) {
@@ -147,6 +147,14 @@ abstract class PandoraContext implements Context, MinkAwareContext
         if ($environment->getSuite()->getName() == 'srv') {
             $this->_webApi = $scope->getEnvironment()->getContext('Behat\WebApiExtension\Context\WebApiContext');
         }
+    }
+
+    /**
+     * @return Doctrine\ORM\EntityManager
+     */
+    protected function _getEntityManager()
+    {
+        return $this->getFixtureBuilder()->getEntityManager();
     }
 
     /**

--- a/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
+++ b/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
@@ -28,10 +28,10 @@ class FixtureBuilderFactory implements FactoryInterface
         $entitiesNamespace = isset($config['entities_namespace']) ? $config['entities_namespace'] : 'Application\Entity';
 
         $fixtureBuilder = new FixtureBuilder($fixtureMetaData, $fixtureNamespace, $entitiesNamespace);
-        if (isset($config['clean_connection']) && is_array($config['clean_connection']) && !empty($config['clean_connection'])) {
+        if (isset($config['connection']) && is_array($config['connection']) && !empty($config['connection'])) {
             $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
-            $fixtureBuilder->setCleanEntityManager(
-                $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
+            $fixtureBuilder->setEntityManager(
+                $this->createEntityManager($defaultEntityManager, $config['connection'])
             );
         }
 
@@ -40,17 +40,17 @@ class FixtureBuilderFactory implements FactoryInterface
 
     /**
      * @param EntityManagerInterface $defaultEntityManager
-     * @param array                  $cleanConnectionConfig
+     * @param array                  $connectionConfig
      *
      * @return EntityManagerInterface
      */
-    protected function createCleanEntityManager(
+    protected function createEntityManager(
         EntityManagerInterface $defaultEntityManager,
-        array $cleanConnectionConfig
+        array $connectionConfig
     ) {
         $connectionParams = array_merge(
             $defaultEntityManager->getConnection()->getParams(),
-            $cleanConnectionConfig
+            $connectionConfig
         );
 
         unset($connectionParams['pdo']);

--- a/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
+++ b/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
@@ -1,6 +1,8 @@
 <?php
 namespace PandoraTestes\Fixture\Factory;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
@@ -24,6 +26,39 @@ class FixtureBuilderFactory implements FactoryInterface
         $fixtureNamespace = isset($config['fixtures_namespace']) ? $config['fixtures_namespace'] : 'Application\Fixture';
         $fixtureMetaData = isset($config['fixtures']) ? $config['fixtures'] : array();
         $entitiesNamespace = isset($config['entities_namespace']) ? $config['entities_namespace'] : 'Application\Entity';
-        return new FixtureBuilder($fixtureMetaData, $fixtureNamespace, $entitiesNamespace);
+
+        $fixtureBuilder = new FixtureBuilder($fixtureMetaData, $fixtureNamespace, $entitiesNamespace);
+        if (isset($config['clean_connection']) && is_array($config['clean_connection'])) {
+            $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
+            $fixtureBuilder->setCleanEntityManager(
+                $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
+            );
+        }
+
+        return $fixtureBuilder;
+    }
+
+    /**
+     * @param EntityManagerInterface $defaultEntityManager
+     * @param array                  $cleanConnectionConfig
+     *
+     * @return EntityManagerInterface
+     */
+    protected function createCleanEntityManager(
+        EntityManagerInterface $defaultEntityManager,
+        array $cleanConnectionConfig
+    ) {
+        $connectionParams = array_merge(
+            $defaultEntityManager->getConnection()->getParams(),
+            $cleanConnectionConfig
+        );
+
+        unset($connectionParams['pdo']);
+
+        return EntityManager::create(
+            $connectionParams,
+            $defaultEntityManager->getConfiguration(),
+            $defaultEntityManager->getEventManager()
+        );
     }
 }

--- a/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
+++ b/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
@@ -28,12 +28,16 @@ class FixtureBuilderFactory implements FactoryInterface
         $entitiesNamespace = isset($config['entities_namespace']) ? $config['entities_namespace'] : 'Application\Entity';
 
         $fixtureBuilder = new FixtureBuilder($fixtureMetaData, $fixtureNamespace, $entitiesNamespace);
-        if (isset($config['clean_connection']) && is_array($config['clean_connection'])) {
-            $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
-            $fixtureBuilder->setCleanEntityManager(
-                $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
+        if (!isset($config['clean_connection']) || !is_array($config['clean_connection']) || empty($config['clean_connection'])) {
+            throw new ServiceNotCreatedException(
+                'A configuração pandora-testes.clean_connection é obrigatória.'
             );
         }
+
+        $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
+        $fixtureBuilder->setCleanEntityManager(
+            $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
+        );
 
         return $fixtureBuilder;
     }

--- a/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
+++ b/src/PandoraTestes/Fixture/Factory/FixtureBuilderFactory.php
@@ -28,16 +28,12 @@ class FixtureBuilderFactory implements FactoryInterface
         $entitiesNamespace = isset($config['entities_namespace']) ? $config['entities_namespace'] : 'Application\Entity';
 
         $fixtureBuilder = new FixtureBuilder($fixtureMetaData, $fixtureNamespace, $entitiesNamespace);
-        if (!isset($config['clean_connection']) || !is_array($config['clean_connection']) || empty($config['clean_connection'])) {
-            throw new ServiceNotCreatedException(
-                'A configuração pandora-testes.clean_connection é obrigatória.'
+        if (isset($config['clean_connection']) && is_array($config['clean_connection']) && !empty($config['clean_connection'])) {
+            $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
+            $fixtureBuilder->setCleanEntityManager(
+                $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
             );
         }
-
-        $defaultEntityManager = $services->get('Doctrine\ORM\EntityManager');
-        $fixtureBuilder->setCleanEntityManager(
-            $this->createCleanEntityManager($defaultEntityManager, $config['clean_connection'])
-        );
 
         return $fixtureBuilder;
     }

--- a/src/PandoraTestes/Fixture/FixtureBuilder.php
+++ b/src/PandoraTestes/Fixture/FixtureBuilder.php
@@ -159,7 +159,7 @@ class FixtureBuilder
     public function getCleanEntityManager()
     {
         if (!$this->cleanEm) {
-            throw new \RuntimeException('O EntityManager de limpeza não foi configurado.');
+            throw new \RuntimeException($this->getMissingCleanConnectionMessage());
         }
 
         return $this->cleanEm;
@@ -271,5 +271,16 @@ class FixtureBuilder
     {
         $driver = $entityManager->getConnection()->getDriver();
         return $driver instanceof \Doctrine\DBAL\Driver\PDOPgSql\Driver;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMissingCleanConnectionMessage()
+    {
+        return
+            "A configuração 'pandora-testes.clean_connection' é obrigatória na v2.0.\n" .
+            "Defina essa chave em config/autoload/*.php com os parâmetros da conexão usada exclusivamente na limpeza do banco.\n" .
+            "Exemplo: 'pandora-testes' => array('clean_connection' => array('driver' => 'pdo_pgsql', 'host' => '127.0.0.1', ...))";
     }
 }

--- a/src/PandoraTestes/Fixture/FixtureBuilder.php
+++ b/src/PandoraTestes/Fixture/FixtureBuilder.php
@@ -19,6 +19,8 @@ class FixtureBuilder
 
     protected $em;
 
+    protected $cleanEm;
+
     protected $entities;
 
     protected $mostrou = false;
@@ -114,20 +116,20 @@ class FixtureBuilder
      */
     public function clean()
     {
-        if ($this->_isPostgres()) {
-            $this->getEntityManager()->getConnection()->exec('SET session_replication_role = replica;');
+        if ($this->_isPostgres($this->getCleanEntityManager())) {
+            $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = replica;');
         }
         $this->entities = array();
         try {
-            $this->_executeFixtures(array(), false);
+            $this->_executeFixtures(array(), false, $this->getCleanEntityManager());
         } catch (\Exception $e) {
-            if ($this->_isPostgres()) {
-                $this->getEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
+            if ($this->_isPostgres($this->getCleanEntityManager())) {
+                $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
             }
             throw $e;
         }
-        if ($this->_isPostgres()) {
-            $this->getEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
+        if ($this->_isPostgres($this->getCleanEntityManager())) {
+            $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
         }
     }
 
@@ -147,6 +149,30 @@ class FixtureBuilder
     public function setEntityManager(EntityManagerInterface $em)
     {
         $this->em = $em;
+
+        return $this;
+    }
+
+    /**
+     * @return \Doctrine\ORM\EntityManagerInterface
+     */
+    public function getCleanEntityManager()
+    {
+        if ($this->cleanEm) {
+            return $this->cleanEm;
+        }
+
+        return $this->getEntityManager();
+    }
+
+    /**
+     * @param EntityManagerInterface $em
+     *
+     * @return \PandoraTestes\Fixture\FixtureBuilder
+     */
+    public function setCleanEntityManager(EntityManagerInterface $em)
+    {
+        $this->cleanEm = $em;
 
         return $this;
     }
@@ -206,10 +232,11 @@ class FixtureBuilder
      * @param array $fixtures
      * @param bool  $append
      */
-    protected function _executeFixtures(array $fixtures, $append)
+    protected function _executeFixtures(array $fixtures, $append, EntityManagerInterface $entityManager = null)
     {
         $purger = new ORMPurger();
-        $executor = new ORMExecutor($this->getEntityManager(), $purger);
+        $entityManager = $entityManager ?: $this->getEntityManager();
+        $executor = new ORMExecutor($entityManager, $purger);
         $executor->execute($fixtures, $append);
     }
 
@@ -240,9 +267,9 @@ class FixtureBuilder
      *
      * @return     boolean  True if postgres, False otherwise.
      */
-    protected function _isPostgres()
+    protected function _isPostgres(EntityManagerInterface $entityManager)
     {
-        $driver = $this->getEntityManager()->getConnection()->getDriver();
+        $driver = $entityManager->getConnection()->getDriver();
         return $driver instanceof \Doctrine\DBAL\Driver\PDOPgSql\Driver;
     }
 }

--- a/src/PandoraTestes/Fixture/FixtureBuilder.php
+++ b/src/PandoraTestes/Fixture/FixtureBuilder.php
@@ -158,11 +158,11 @@ class FixtureBuilder
      */
     public function getCleanEntityManager()
     {
-        if ($this->cleanEm) {
-            return $this->cleanEm;
+        if (!$this->cleanEm) {
+            throw new \RuntimeException('O EntityManager de limpeza não foi configurado.');
         }
 
-        return $this->getEntityManager();
+        return $this->cleanEm;
     }
 
     /**

--- a/src/PandoraTestes/Fixture/FixtureBuilder.php
+++ b/src/PandoraTestes/Fixture/FixtureBuilder.php
@@ -19,8 +19,6 @@ class FixtureBuilder
 
     protected $em;
 
-    protected $cleanEm;
-
     protected $entities;
 
     protected $mostrou = false;
@@ -80,7 +78,7 @@ class FixtureBuilder
 
     public function registraEntidade($fixtureName, $createdEntity)
     {
-        $classMetadata = $this->em->getClassMetaData(get_class($createdEntity));
+        $classMetadata = $this->getEntityManager()->getClassMetaData(get_class($createdEntity));
         $id = $classMetadata->getIdentifierValues($createdEntity);
         $this->entities[$fixtureName] = [
             'class' => get_class($createdEntity),
@@ -90,7 +88,7 @@ class FixtureBuilder
 
     protected function _recuperaEntidade($fixtureName)
     {
-        return $this->em->find(
+        return $this->getEntityManager()->find(
             $this->entities[$fixtureName]['class'],
             $this->entities[$fixtureName]['id']
         );
@@ -116,20 +114,20 @@ class FixtureBuilder
      */
     public function clean()
     {
-        if ($this->_isPostgres($this->getCleanEntityManager())) {
-            $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = replica;');
+        if ($this->_isPostgres($this->getEntityManager())) {
+            $this->getEntityManager()->getConnection()->exec('SET session_replication_role = replica;');
         }
         $this->entities = array();
         try {
-            $this->_executeFixtures(array(), false, $this->getCleanEntityManager());
+            $this->_executeFixtures(array(), false);
         } catch (\Exception $e) {
-            if ($this->_isPostgres($this->getCleanEntityManager())) {
-                $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
+            if ($this->_isPostgres($this->getEntityManager())) {
+                $this->getEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
             }
             throw $e;
         }
-        if ($this->_isPostgres($this->getCleanEntityManager())) {
-            $this->getCleanEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
+        if ($this->_isPostgres($this->getEntityManager())) {
+            $this->getEntityManager()->getConnection()->exec('SET session_replication_role = DEFAULT;');
         }
     }
 
@@ -138,6 +136,10 @@ class FixtureBuilder
      */
     public function getEntityManager()
     {
+        if (!$this->em) {
+            throw new \RuntimeException($this->getMissingConnectionMessage());
+        }
+
         return $this->em;
     }
 
@@ -149,30 +151,6 @@ class FixtureBuilder
     public function setEntityManager(EntityManagerInterface $em)
     {
         $this->em = $em;
-
-        return $this;
-    }
-
-    /**
-     * @return \Doctrine\ORM\EntityManagerInterface
-     */
-    public function getCleanEntityManager()
-    {
-        if (!$this->cleanEm) {
-            throw new \RuntimeException($this->getMissingCleanConnectionMessage());
-        }
-
-        return $this->cleanEm;
-    }
-
-    /**
-     * @param EntityManagerInterface $em
-     *
-     * @return \PandoraTestes\Fixture\FixtureBuilder
-     */
-    public function setCleanEntityManager(EntityManagerInterface $em)
-    {
-        $this->cleanEm = $em;
 
         return $this;
     }
@@ -232,11 +210,10 @@ class FixtureBuilder
      * @param array $fixtures
      * @param bool  $append
      */
-    protected function _executeFixtures(array $fixtures, $append, EntityManagerInterface $entityManager = null)
+    protected function _executeFixtures(array $fixtures, $append)
     {
         $purger = new ORMPurger();
-        $entityManager = $entityManager ?: $this->getEntityManager();
-        $executor = new ORMExecutor($entityManager, $purger);
+        $executor = new ORMExecutor($this->getEntityManager(), $purger);
         $executor->execute($fixtures, $append);
     }
 
@@ -276,11 +253,11 @@ class FixtureBuilder
     /**
      * @return string
      */
-    protected function getMissingCleanConnectionMessage()
+    protected function getMissingConnectionMessage()
     {
         return
-            "A configuração 'pandora-testes.clean_connection' é obrigatória na v2.0.\n" .
-            "Defina essa chave em config/autoload/*.php com os parâmetros da conexão usada exclusivamente na limpeza do banco.\n" .
-            "Exemplo: 'pandora-testes' => array('clean_connection' => array('driver' => 'pdo_pgsql', 'host' => '127.0.0.1', ...))";
+            "A configuração 'pandora-testes.connection' é obrigatória na v2.0.\n" .
+            "Defina essa chave em config/autoload/*.php com os parâmetros da conexão usada pela biblioteca para limpar e manipular as fixtures.\n" .
+            "Exemplo: 'pandora-testes' => array('connection' => array('driver' => 'pdo_pgsql', 'host' => '127.0.0.1', ...))";
     }
 }


### PR DESCRIPTION
## Summary
- require `pandora-testes.connection` and remove the fallback to the default Doctrine connection
- fail explicitly when the entity manager is not configured
- document that this breaking change ships in `v2.0`

## Validation
- composer validate --no-check-publish --no-check-lock
- find src -name '*.php' -print0 | xargs -0 -n1 php -l